### PR TITLE
Remove hardcoded autoloader reference

### DIFF
--- a/lib/mcrypt.php
+++ b/lib/mcrypt.php
@@ -30,8 +30,6 @@
  * @link      http://phpseclib.sourceforge.net
  */
 
-require __DIR__ . '/../vendor/autoload.php';
-
 use phpseclib\Crypt\Rijndael;
 use phpseclib\Crypt\Twofish;
 use phpseclib\Crypt\Blowfish;


### PR DESCRIPTION
Hi,

Thanks a bunch for this library its saved a lot of time!

When using it I ran into a problem with the require statement breaking. I'm guessing this is because it was being used as the main project during development and had it's own vendor directory at the time:

PHP Warning:  require(/var/www/html/vendor/phpseclib/mcrypt_compat/lib/../vendor/autoload.php): failed to open stream: No such file or directory in /var/www/html/vendor/phpseclib/mcrypt_compat/lib/mcrypt.php on line 33, 

Removing it fixes this and the tests still work.
