### PR TITLE
As the ECB mode cannot use IVs, allow NULL IVs.

### DIFF
--- a/lib/mcrypt.php
+++ b/lib/mcrypt.php
@@ -180,7 +180,7 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
      */
     function phpseclib_set_iv(Base $td, $iv)
     {
-        if ($td->mcrypt_mode != 'stream' && $td->mcrypt_mode != 'ecb') {
+        if (phpseclib_mcrypt_module_is_iv_mode($td->mcrypt_mode)) {
             $length = $td->getBlockLength() >> 3;
             $iv = str_pad(substr($iv, 0, $length), $length, "\0");
             $td->setIV($iv);
@@ -632,9 +632,7 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
     }
 
     /**
-     * Returns the maximum supported keysize of the opened mode
-     *
-     * Gets the maximum supported key size of the algorithm in bytes.
+     * This function initializes all buffers needed for en/decryption.
      *
      * @param \phpseclib\Crypt\Base $td
      * @param string $key
@@ -645,7 +643,7 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
     function phpseclib_mcrypt_generic_init(Base $td, $key, $iv)
     {
         $iv_size = phpseclib_mcrypt_enc_get_iv_size($td);
-        if (strlen($iv) != $iv_size) {
+        if (strlen($iv) != $iv_size && $td->mcrypt_mode != 'ecb') {
             trigger_error('mcrypt_generic_init(): Iv size incorrect; supplied length: ' . strlen($iv) . ', needed: ' . $iv_size, E_USER_WARNING);
         }
         if (!strlen($key)) {
@@ -688,7 +686,7 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
         }
 
         // phpseclib does not currently provide a way to retrieve the mode once it has been set via "public" methods
-        if ($td->mcrypt_mode == 'cbc' || $td->mcrypt_mode == 'ecb') {
+        if (phpseclib_mcrypt_module_is_block_mode($td->mcrypt_mode)) {
             $block_length = phpseclib_mcrypt_enc_get_iv_size($td);
             $extra = strlen($data) % $block_length;
             if ($extra) {
@@ -900,6 +898,23 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
     }
 
     /**
+     * Returns if the specified mode can use an IV or not
+     *
+     * @param string $mode
+     * @return bool
+     * @access public
+     */
+    function phpseclib_mcrypt_module_is_iv_mode($mode)
+    {
+        switch ($mode) {
+            case 'ecb':
+            case 'stream':
+                return false;
+        }
+        return true;
+    }
+
+    /**
      * This function runs a self test on the specified module
      *
      * This function runs the self test on the algorithm specified.
@@ -956,20 +971,24 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
             );
             return false;
         }
-        $iv_size = phpseclib_mcrypt_enc_get_iv_size($td);
-        if (!isset($iv) && $iv_size) {
-            trigger_error(
-                'mcrypt_' . $op . '(): Encryption mode requires an initialization vector of size  ' . $iv_size,
-                E_USER_WARNING
-            );
-            return false;
-        }
-        if (strlen($iv) != $iv_size) {
-            trigger_error(
-                'mcrypt_' . $op . '(): Received initialization vector of size  ' . strlen($iv) . ', but size ' . $iv_size . ' is required for this encryption mode',
-                E_USER_WARNING
-            );
-            return false;
+        if (phpseclib_mcrypt_module_is_iv_mode($mode)) {
+            $iv_size = phpseclib_mcrypt_enc_get_iv_size($td);
+            if (!isset($iv) && $iv_size) {
+                trigger_error(
+                    'mcrypt_' . $op . '(): Encryption mode requires an initialization vector of size ' . $iv_size,
+                    E_USER_WARNING
+                );
+                return false;
+            }
+            if (strlen($iv) != $iv_size) {
+                trigger_error(
+                    'mcrypt_' . $op . '(): Received initialization vector of size ' . strlen($iv) . ', but size ' . $iv_size . ' is required for this encryption mode',
+                    E_USER_WARNING
+                );
+                return false;
+            }
+        } else {
+            $iv = null;
         }
         phpseclib_mcrypt_generic_init($td, $key, $iv);
         return $op == 'encrypt' ? phpseclib_mcrypt_generic($td, $data) : phpseclib_mdecrypt_generic($td, $data);
@@ -1068,7 +1087,7 @@ if (!function_exists('phpseclib_mcrypt_list_algorithms')) {
         public function filter($in, $out, &$consumed, $closing)
         {
             $newlen = 0;
-            $block_mode = $this->cipher->mcrypt_mode == 'cbc' || $this->cipher->mcrypt_mode == 'ecb';
+            $block_mode = phpseclib_mcrypt_module_is_block_mode($this->cipher->mcrypt_mode);
             while ($bucket = stream_bucket_make_writeable($in)) {
                 if ($block_mode) {
                     $bucket->data = $this->buffer . $bucket->data;


### PR DESCRIPTION
Hi,

first off, thanks for making this library in spite of the pile of WTFs that mcrypt is :)

I noticed that mcrypt_compat does not accept empty IVs in ECB mode. The ECB mode naturally can't use IVs, so it should be accpted - the original mcrypt extension allows it as well.

The patch needs some more love, let me know what you think.