### PR TITLE
Add "provide" key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
     "suggest": {
         "ext-openssl": "Will enable faster cryptographic operations"
     },
+    "provide": {
+        "ext-mcrypt": "*"
+    },
     "autoload": {
         "files": ["lib/mcrypt.php"]
     }


### PR DESCRIPTION
According to one of my colleagues, @odan, your compat library can be used to circumvent the missing mcrypt extension in PHP 7.2 on Windows.

See comment:

https://github.com/cakephp/cakephp/issues/11346#issuecomment-364400457



